### PR TITLE
[Refactor] Green 색상명 대문자로 변환

### DIFF
--- a/SnakeAndApple.py
+++ b/SnakeAndApple.py
@@ -102,7 +102,7 @@ class SnakeAndApple:
             size_of_board / 2,
             3 * size_of_board / 8,
             font="cmr 40 bold",
-            fill=Green_color,
+            fill=GREEN_COLOR,
             text=score_text,
             )
         score_text = str(score)


### PR DESCRIPTION
내용: 충돌과정에서 그린컬러 상수를 대문자로 변환했지만 실제 적용을 안한 누락된부분 수정해서 다시 PR 올립니다!
변경내용: 상수명을 대문자로 전환